### PR TITLE
allow using a separate plantuml file

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ var PLANTUML_JAR = path.join(__dirname, 'vendor/plantuml.jar');
 
 var entities = new Entities();
 
+var pageInfo;
+
 function hashedImageName(content) {
   var md5sum = crypto.createHash('md5');
   md5sum.update(content);
@@ -33,7 +35,18 @@ module.exports = {
         var defaultFormat = this.generator == 'ebook'? '.png' : '.svg';
         var outputFormat = this.generator == 'ebook'? '-tpng' : '-tsvg';
 
-        var umlText = parseUmlText(block.body);
+
+        var umlText ;
+        if (block.kwargs && block.kwargs.path) {
+          var pumlPath = block.kwargs.path;
+          if (pageInfo.directory)  {
+            pumlPath = pageInfo.directory + '/' + pumlPath;
+          }
+          var resolvedPath = this.book.resolve(pumlPath);
+          umlText = fs.readFileSync(resolvedPath, 'utf8');
+        }  else  {
+          umlText= parseUmlText(block.body);
+        }
         var re = /@startditaa/
 
         if (re.test(umlText)) {
@@ -70,6 +83,13 @@ module.exports = {
 
         return "<img src=\"" + path.join("/", imageName) + "\"/>";
       }
+    }
+  },
+  hooks: {
+    'page:before': function(page) {
+      var pagePath = page.path;
+      pageInfo = { directory: pagePath.substring(0, pagePath.lastIndexOf("/"))};
+      return page;
     }
   }
 };

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,18 @@ puml images locally rather than using the service at http://www.plantuml.com/pla
 
 This is necessary if you are using/hosting gitbook for private work and don't want your diagrams bounced off an external server.
 
+You can specify the plantuml script either in the plantuml block:
+
+ {% plantuml %}
+ Bob->Alice : hello
+ {% endplantuml %}
+
+Or by referencing a separate .puml file:
+
+ {% plantuml path='bob_alice.puml'%}
+ {% endplantuml %}
+
+
 # Release Notes
 `1.0.1` Support for caching of output images in the os temp directory. Since the filenames are based on the hash of the diagram text, versioning should 'just work'. This also helps
 with the slow-ness listed in issues by only re-rendering changed images. Thanks to @johnhug for the contribution.

--- a/test/test.js
+++ b/test/test.js
@@ -37,4 +37,17 @@ describe('PlantUML', function() {
                 assert.equal(result.get("nesting/nested.html").content, '<p>This is a diagram:</p>\n<p><img src="../84918a9a66a4e75be00a46643eab802f.svg"></p>')
             });
     });
+    it('should correctly replace file reference by img html tag in book root', function() {
+        return tester.builder()
+            .withFile('test.puml','Bob->Alice : hello')
+            .withContent('This is a diagram:\n\n{% plantuml path="test.puml" %}\ntest\n{% endplantuml %}')
+            .withBookJson({
+                plugins: ['local-plantuml']
+            })
+            .withLocalPlugin(path.join(__dirname, '..'))
+            .create()
+            .then(function(result) {
+                assert.equal(result[0].content, '<p>This is a diagram:</p>\n<p><img src="84918a9a66a4e75be00a46643eab802f.svg"></p>')
+            });
+    });
 });


### PR DESCRIPTION
I have the need as the one described in the issue #3 "Allow Handling of Separate Files containing PlantUml "

This patch allows using a separate file to define the plantuml script.
This allows using a plantuml plugin to edit it.

The file name is set in an attribute of the block:
 {% plantuml path='bob_alice.puml'%}
 {% endplantuml %}

